### PR TITLE
Implement account billing domain with service, controllers, entities, migration and tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,28 @@ services:
     networks:
       - parking-network
 
+
+
+  account-service:
+    build:
+      context: ./parking-account-service
+    image: parking-account-service:local
+    environment:
+      EUREKA_CLIENT_SERVICEURL_DEFAULTZONE: http://eureka-server:8761/eureka
+      SERVER_PORT: 8081
+      SPRING_DATASOURCE_URL: jdbc:postgresql://user-db:5432/postgres
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:29092
+    ports:
+      - "8081:8081"
+    depends_on:
+      gateway:
+        condition: service_healthy
+      user-db:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    networks:
+      - parking-network
   reservation-service:
     build:
       context: ./parking-reservation-service

--- a/parking-account-service/Dockerfile
+++ b/parking-account-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:8.10.2-jdk17 AS builder
+WORKDIR /app
+COPY . .
+RUN gradle --no-daemon bootJar
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=builder /app/build/libs/*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/parking-account-service/build.gradle
+++ b/parking-account-service/build.gradle
@@ -25,14 +25,18 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-kafka'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.flywaydb:flyway-core'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/parking-account-service/build.gradle
+++ b/parking-account-service/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-kafka'
+    implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.flywaydb:flyway-core'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -36,7 +36,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/controller/AccountController.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/controller/AccountController.java
@@ -1,0 +1,42 @@
+package ru.dstu.work.parkingaccountservice.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+import ru.dstu.work.parkingaccountservice.dto.ReservationBillingRequest;
+import ru.dstu.work.parkingaccountservice.dto.TopUpRequest;
+import ru.dstu.work.parkingaccountservice.entity.AccountOperation;
+import ru.dstu.work.parkingaccountservice.entity.Account;
+import ru.dstu.work.parkingaccountservice.service.AccountService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/accounts")
+public class AccountController {
+
+    private final AccountService accountService;
+
+    public AccountController(AccountService accountService) {
+        this.accountService = accountService;
+    }
+
+    @PostMapping("/{email}/top-up")
+    public Account topUp(@PathVariable String email, @Valid @RequestBody TopUpRequest request) {
+        return accountService.topUp(email, request.operationId(), request.amount());
+    }
+
+    @PostMapping("/reservation-event")
+    public Account applyReservationEvent(@Valid @RequestBody ReservationBillingRequest request) {
+        return accountService.applyReservationBilling(request);
+    }
+
+    @GetMapping("/{email}")
+    public Account getWallet(@PathVariable String email) {
+        return accountService.getAccount(email);
+    }
+
+    @GetMapping("/{email}/operations")
+    public List<AccountOperation> history(@PathVariable String email) {
+        return accountService.getOperationHistory(email);
+    }
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/dto/ReservationBillingRequest.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/dto/ReservationBillingRequest.java
@@ -1,0 +1,18 @@
+package ru.dstu.work.parkingaccountservice.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import ru.dstu.work.parkingaccountservice.entity.ReservationStatus;
+
+import java.math.BigDecimal;
+
+public record ReservationBillingRequest(
+        @NotBlank String operationId,
+        @NotNull Long reservationId,
+        @NotBlank String userEmail,
+        @NotNull ReservationStatus status,
+        @NotNull @DecimalMin(value = "0.00") BigDecimal totalAmount,
+        Integer refundPercent
+) {
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/dto/TopUpRequest.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/dto/TopUpRequest.java
@@ -1,0 +1,13 @@
+package ru.dstu.work.parkingaccountservice.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record TopUpRequest(
+        @NotBlank String operationId,
+        @NotNull @DecimalMin(value = "0.01") BigDecimal amount
+) {
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/Account.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/Account.java
@@ -1,0 +1,29 @@
+package ru.dstu.work.parkingaccountservice.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "account", schema = "public")
+@Getter
+@Setter
+public class Account {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal balance = BigDecimal.ZERO;
+
+    @Column(name = "held_amount", nullable = false, precision = 14, scale = 2)
+    private BigDecimal heldAmount = BigDecimal.ZERO;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AccountStatus status = AccountStatus.OPEN;
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/AccountOperation.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/AccountOperation.java
@@ -1,0 +1,50 @@
+package ru.dstu.work.parkingaccountservice.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "account_operation", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_account_operation_id", columnNames = "operationId")
+})
+@Getter
+@Setter
+public class AccountOperation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String operationId;
+
+    @Column(nullable = false)
+    private String userEmail;
+
+    @Column(nullable = false)
+    private Long accountId;
+
+    private Long reservationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OperationType type;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal amount;
+
+    @Column(nullable = false, length = 1024)
+    private String details;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/AccountStatus.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/AccountStatus.java
@@ -1,0 +1,7 @@
+package ru.dstu.work.parkingaccountservice.entity;
+
+public enum AccountStatus {
+    OPEN,
+    BLOCKED,
+    CLOSED
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/OperationType.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/OperationType.java
@@ -1,0 +1,9 @@
+package ru.dstu.work.parkingaccountservice.entity;
+
+public enum OperationType {
+    TOP_UP,
+    HOLD,
+    CAPTURE,
+    REFUND,
+    PENALTY
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/ReservationLedger.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/ReservationLedger.java
@@ -1,0 +1,64 @@
+package ru.dstu.work.parkingaccountservice.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reservation_ledger", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_reservation_ledger_reservation", columnNames = "reservationId")
+})
+@Getter
+@Setter
+public class ReservationLedger {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long reservationId;
+
+    @Column(nullable = false)
+    private String userEmail;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal totalAmount = BigDecimal.ZERO;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal heldAmount = BigDecimal.ZERO;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal capturedAmount = BigDecimal.ZERO;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal refundedAmount = BigDecimal.ZERO;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal penaltyAmount = BigDecimal.ZERO;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus lastStatus = ReservationStatus.HOLD;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/ReservationStatus.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/entity/ReservationStatus.java
@@ -1,0 +1,11 @@
+package ru.dstu.work.parkingaccountservice.entity;
+
+public enum ReservationStatus {
+    HOLD,
+    CONFIRMED,
+    ACTIVE,
+    COMPLETED,
+    CANCELLED,
+    EXPIRED,
+    NO_SHOW
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/exception/BadRequestException.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package ru.dstu.work.parkingaccountservice.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/exception/RestExceptionHandler.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/exception/RestExceptionHandler.java
@@ -1,0 +1,29 @@
+package ru.dstu.work.parkingaccountservice.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequest(BadRequestException ex) {
+        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        return ResponseEntity.badRequest().body(Map.of("error", "Ошибка валидации входных данных"));
+    }
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/repository/AccountOperationRepository.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/repository/AccountOperationRepository.java
@@ -1,0 +1,13 @@
+package ru.dstu.work.parkingaccountservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.dstu.work.parkingaccountservice.entity.AccountOperation;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AccountOperationRepository extends JpaRepository<AccountOperation, Long> {
+    Optional<AccountOperation> findByOperationId(String operationId);
+
+    List<AccountOperation> findByUserEmailOrderByCreatedAtDesc(String userEmail);
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/repository/AccountRepository.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/repository/AccountRepository.java
@@ -1,0 +1,22 @@
+package ru.dstu.work.parkingaccountservice.repository;
+
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import ru.dstu.work.parkingaccountservice.entity.Account;
+
+import java.util.Optional;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(value = """
+            select a.*
+            from public.account a
+            join public.users u on u.account_id = a.id
+            where u.email = :email
+            """, nativeQuery = true)
+    Optional<Account> findByUserEmailForUpdate(@Param("email") String email);
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/repository/ReservationLedgerRepository.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/repository/ReservationLedgerRepository.java
@@ -1,0 +1,10 @@
+package ru.dstu.work.parkingaccountservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.dstu.work.parkingaccountservice.entity.ReservationLedger;
+
+import java.util.Optional;
+
+public interface ReservationLedgerRepository extends JpaRepository<ReservationLedger, Long> {
+    Optional<ReservationLedger> findByReservationId(Long reservationId);
+}

--- a/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/service/AccountService.java
+++ b/parking-account-service/src/main/java/ru/dstu/work/parkingaccountservice/service/AccountService.java
@@ -1,0 +1,221 @@
+package ru.dstu.work.parkingaccountservice.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.dstu.work.parkingaccountservice.dto.ReservationBillingRequest;
+import ru.dstu.work.parkingaccountservice.entity.*;
+import ru.dstu.work.parkingaccountservice.exception.BadRequestException;
+import ru.dstu.work.parkingaccountservice.repository.AccountOperationRepository;
+import ru.dstu.work.parkingaccountservice.repository.AccountRepository;
+import ru.dstu.work.parkingaccountservice.repository.ReservationLedgerRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Service
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+    private final AccountOperationRepository operationRepository;
+    private final ReservationLedgerRepository ledgerRepository;
+
+    public AccountService(AccountRepository accountRepository,
+                          AccountOperationRepository operationRepository,
+                          ReservationLedgerRepository ledgerRepository) {
+        this.accountRepository = accountRepository;
+        this.operationRepository = operationRepository;
+        this.ledgerRepository = ledgerRepository;
+    }
+
+    @Transactional
+    public Account topUp(String userEmail, String operationId, BigDecimal amount) {
+        validateAmount(amount);
+        Account account = getAccountByUserEmail(userEmail);
+        if (operationRepository.findByOperationId(operationId).isPresent()) {
+            return account;
+        }
+
+        account.setBalance(account.getBalance().add(amount));
+        accountRepository.save(account);
+        saveOperation(operationId, userEmail, account.getId(), null, OperationType.TOP_UP, amount, "wallet top up");
+        return account;
+    }
+
+    @Transactional
+    public Account applyReservationBilling(ReservationBillingRequest request) {
+        Account account = getAccountByUserEmail(request.userEmail());
+        if (operationRepository.findByOperationId(request.operationId()).isPresent()) {
+            return account;
+        }
+
+        return switch (request.status()) {
+            case HOLD -> holdFunds(account, request);
+            case ACTIVE, COMPLETED -> captureOnUsage(account, request);
+            case CANCELLED -> cancelWithRefundPolicy(account, request);
+            case EXPIRED -> expireWithFullRefund(account, request);
+            case NO_SHOW -> closeAsNoShow(account, request);
+            case CONFIRMED -> account;
+        };
+    }
+
+    public List<AccountOperation> getOperationHistory(String userEmail) {
+        return operationRepository.findByUserEmailOrderByCreatedAtDesc(userEmail);
+    }
+
+    public Account getAccount(String userEmail) {
+        return getAccountByUserEmail(userEmail);
+    }
+
+    private Account holdFunds(Account account, ReservationBillingRequest request) {
+        validateAmount(request.totalAmount());
+        if (account.getBalance().compareTo(request.totalAmount()) < 0) {
+            throw new BadRequestException("Недостаточно средств для HOLD операции");
+        }
+
+        account.setBalance(account.getBalance().subtract(request.totalAmount()));
+        account.setHeldAmount(account.getHeldAmount().add(request.totalAmount()));
+        accountRepository.save(account);
+
+        ReservationLedger ledger = new ReservationLedger();
+        ledger.setReservationId(request.reservationId());
+        ledger.setUserEmail(request.userEmail());
+        ledger.setTotalAmount(request.totalAmount());
+        ledger.setHeldAmount(request.totalAmount());
+        ledger.setLastStatus(ReservationStatus.HOLD);
+        ledgerRepository.save(ledger);
+
+        saveOperation(request.operationId(), request.userEmail(), account.getId(), request.reservationId(), OperationType.HOLD,
+                request.totalAmount(), "reservation hold for 5 minutes");
+        return account;
+    }
+
+    private Account captureOnUsage(Account account, ReservationBillingRequest request) {
+        ReservationLedger ledger = getLedger(request.reservationId());
+
+        BigDecimal toCapture = ledger.getHeldAmount();
+        if (toCapture.compareTo(BigDecimal.ZERO) > 0) {
+            account.setHeldAmount(account.getHeldAmount().subtract(toCapture));
+            ledger.setHeldAmount(BigDecimal.ZERO);
+            ledger.setCapturedAmount(ledger.getCapturedAmount().add(toCapture));
+            saveOperation(request.operationId(), request.userEmail(), account.getId(), request.reservationId(), OperationType.CAPTURE,
+                    toCapture, "captured on status " + request.status());
+        }
+        ledger.setLastStatus(request.status());
+        accountRepository.save(account);
+        ledgerRepository.save(ledger);
+        return account;
+    }
+
+    private Account cancelWithRefundPolicy(Account account, ReservationBillingRequest request) {
+        ReservationLedger ledger = getLedger(request.reservationId());
+
+        int refundPercent = request.refundPercent() == null ? 0 : request.refundPercent();
+        if (refundPercent < 0 || refundPercent > 100) {
+            throw new BadRequestException("refundPercent должен быть в диапазоне 0..100");
+        }
+
+        BigDecimal held = ledger.getHeldAmount();
+        BigDecimal refund = percentOf(held, refundPercent);
+        BigDecimal penalty = held.subtract(refund);
+
+        if (refund.compareTo(BigDecimal.ZERO) > 0) {
+            account.setBalance(account.getBalance().add(refund));
+            ledger.setRefundedAmount(ledger.getRefundedAmount().add(refund));
+            saveOperation(request.operationId() + "-REFUND", request.userEmail(), account.getId(), request.reservationId(), OperationType.REFUND,
+                    refund, "cancel refund " + refundPercent + "%");
+        }
+
+        if (penalty.compareTo(BigDecimal.ZERO) > 0) {
+            ledger.setPenaltyAmount(ledger.getPenaltyAmount().add(penalty));
+            saveOperation(request.operationId(), request.userEmail(), account.getId(), request.reservationId(), OperationType.PENALTY,
+                    penalty, "cancel penalty " + (100 - refundPercent) + "%");
+        }
+
+        account.setHeldAmount(account.getHeldAmount().subtract(held));
+        ledger.setHeldAmount(BigDecimal.ZERO);
+        ledger.setLastStatus(ReservationStatus.CANCELLED);
+        accountRepository.save(account);
+        ledgerRepository.save(ledger);
+        return account;
+    }
+
+    private Account expireWithFullRefund(Account account, ReservationBillingRequest request) {
+        ReservationLedger ledger = getLedger(request.reservationId());
+
+        BigDecimal held = ledger.getHeldAmount();
+        account.setBalance(account.getBalance().add(held));
+        account.setHeldAmount(account.getHeldAmount().subtract(held));
+
+        ledger.setHeldAmount(BigDecimal.ZERO);
+        ledger.setRefundedAmount(ledger.getRefundedAmount().add(held));
+        ledger.setLastStatus(ReservationStatus.EXPIRED);
+
+        accountRepository.save(account);
+        ledgerRepository.save(ledger);
+
+        saveOperation(request.operationId(), request.userEmail(), account.getId(), request.reservationId(), OperationType.REFUND,
+                held, "full refund on EXPIRED");
+        return account;
+    }
+
+    private Account closeAsNoShow(Account account, ReservationBillingRequest request) {
+        ReservationLedger ledger = getLedger(request.reservationId());
+
+        BigDecimal held = ledger.getHeldAmount();
+        account.setHeldAmount(account.getHeldAmount().subtract(held));
+        ledger.setHeldAmount(BigDecimal.ZERO);
+        ledger.setPenaltyAmount(ledger.getPenaltyAmount().add(held));
+        ledger.setLastStatus(ReservationStatus.NO_SHOW);
+
+        accountRepository.save(account);
+        ledgerRepository.save(ledger);
+
+        saveOperation(request.operationId(), request.userEmail(), account.getId(), request.reservationId(), OperationType.PENALTY,
+                held, "no-show penalty 100%");
+        return account;
+    }
+
+    private ReservationLedger getLedger(Long reservationId) {
+        return ledgerRepository.findByReservationId(reservationId)
+                .orElseThrow(() -> new EntityNotFoundException("Ledger по брони не найден"));
+    }
+
+    private Account getAccountByUserEmail(String userEmail) {
+        return accountRepository.findByUserEmailForUpdate(userEmail)
+                .orElseThrow(() -> new EntityNotFoundException("Аккаунт пользователя не найден"));
+    }
+
+    private BigDecimal percentOf(BigDecimal total, int percent) {
+        return total.multiply(BigDecimal.valueOf(percent))
+                .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
+    }
+
+    private void validateAmount(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BadRequestException("Сумма должна быть больше 0");
+        }
+    }
+
+    private void saveOperation(String operationId,
+                               String userEmail,
+                               Long accountId,
+                               Long reservationId,
+                               OperationType type,
+                               BigDecimal amount,
+                               String details) {
+        if (operationRepository.findByOperationId(operationId).isPresent()) {
+            return;
+        }
+        AccountOperation operation = new AccountOperation();
+        operation.setOperationId(operationId);
+        operation.setUserEmail(userEmail);
+        operation.setAccountId(accountId);
+        operation.setReservationId(reservationId);
+        operation.setType(type);
+        operation.setAmount(amount);
+        operation.setDetails(details);
+        operationRepository.save(operation);
+    }
+}

--- a/parking-account-service/src/main/resources/application.properties
+++ b/parking-account-service/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=parking-account-service
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration

--- a/parking-account-service/src/main/resources/db/migration/V1__account_billing_init.sql
+++ b/parking-account-service/src/main/resources/db/migration/V1__account_billing_init.sql
@@ -1,0 +1,31 @@
+ALTER TABLE IF EXISTS public.account
+    ADD COLUMN IF NOT EXISTS held_amount NUMERIC(14,2) NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS public.account_operation (
+    id BIGSERIAL PRIMARY KEY,
+    operation_id VARCHAR(255) NOT NULL UNIQUE,
+    user_email VARCHAR(255) NOT NULL,
+    account_id BIGINT NOT NULL,
+    reservation_id BIGINT,
+    type VARCHAR(32) NOT NULL,
+    amount NUMERIC(14,2) NOT NULL,
+    details VARCHAR(1024) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.reservation_ledger (
+    id BIGSERIAL PRIMARY KEY,
+    reservation_id BIGINT NOT NULL UNIQUE,
+    user_email VARCHAR(255) NOT NULL,
+    total_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+    held_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+    captured_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+    refunded_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+    penalty_amount NUMERIC(14,2) NOT NULL DEFAULT 0,
+    last_status VARCHAR(32) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_operation_email ON public.account_operation(user_email);
+CREATE INDEX IF NOT EXISTS idx_account_operation_account ON public.account_operation(account_id);

--- a/parking-account-service/src/test/java/ru/dstu/work/parkingaccountservice/service/AccountServiceTest.java
+++ b/parking-account-service/src/test/java/ru/dstu/work/parkingaccountservice/service/AccountServiceTest.java
@@ -1,0 +1,80 @@
+package ru.dstu.work.parkingaccountservice.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import ru.dstu.work.parkingaccountservice.dto.ReservationBillingRequest;
+import ru.dstu.work.parkingaccountservice.entity.Account;
+import ru.dstu.work.parkingaccountservice.entity.ReservationStatus;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AccountServiceTest {
+
+    @Autowired
+    private AccountService accountService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void prepareUsersTable() {
+        jdbcTemplate.execute("CREATE TABLE IF NOT EXISTS users (id BIGINT AUTO_INCREMENT PRIMARY KEY, email VARCHAR(255), account_id BIGINT)");
+    }
+
+    @Test
+    void shouldHoldAndCaptureAndBeIdempotent() {
+        String email = "user1@test.com";
+        long accountId = createUserWithAccount(email, BigDecimal.valueOf(1000));
+
+        Account toppedUp = accountService.topUp(email, "topup-1", BigDecimal.valueOf(100));
+        assertThat(toppedUp.getId()).isEqualTo(accountId);
+
+        Account holdAccount = accountService.applyReservationBilling(new ReservationBillingRequest(
+                "hold-1", 10L, email, ReservationStatus.HOLD, BigDecimal.valueOf(300), null
+        ));
+
+        assertThat(holdAccount.getBalance()).isEqualByComparingTo("800.00");
+        assertThat(holdAccount.getHeldAmount()).isEqualByComparingTo("300.00");
+
+        Account idempotentHold = accountService.applyReservationBilling(new ReservationBillingRequest(
+                "hold-1", 10L, email, ReservationStatus.HOLD, BigDecimal.valueOf(300), null
+        ));
+        assertThat(idempotentHold.getBalance()).isEqualByComparingTo("800.00");
+
+        Account activeAccount = accountService.applyReservationBilling(new ReservationBillingRequest(
+                "capture-1", 10L, email, ReservationStatus.ACTIVE, BigDecimal.valueOf(300), null
+        ));
+        assertThat(activeAccount.getHeldAmount()).isEqualByComparingTo("0.00");
+        assertThat(activeAccount.getBalance()).isEqualByComparingTo("800.00");
+    }
+
+    @Test
+    void shouldApplyCancellationRefundPolicy() {
+        String email = "user2@test.com";
+        createUserWithAccount(email, BigDecimal.valueOf(1000));
+
+        accountService.applyReservationBilling(new ReservationBillingRequest(
+                "hold-2", 20L, email, ReservationStatus.HOLD, BigDecimal.valueOf(500), null
+        ));
+
+        Account cancelledAccount = accountService.applyReservationBilling(new ReservationBillingRequest(
+                "cancel-2", 20L, email, ReservationStatus.CANCELLED, BigDecimal.valueOf(500), 80
+        ));
+
+        assertThat(cancelledAccount.getBalance()).isEqualByComparingTo("900.00");
+        assertThat(cancelledAccount.getHeldAmount()).isEqualByComparingTo("0.00");
+    }
+
+    private long createUserWithAccount(String email, BigDecimal balance) {
+        jdbcTemplate.update("INSERT INTO account(balance, held_amount, status) VALUES (?, ?, ?)", balance, BigDecimal.ZERO, "OPEN");
+        Long accountId = jdbcTemplate.queryForObject("SELECT MAX(id) FROM account", Long.class);
+        jdbcTemplate.update("INSERT INTO users(email, account_id) VALUES (?, ?)", email, accountId);
+        return accountId;
+    }
+}

--- a/parking-account-service/src/test/resources/application.properties
+++ b/parking-account-service/src/test/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.flyway.enabled=false


### PR DESCRIPTION
### Motivation
- Implement a full account billing subsystem to support wallet top-ups and reservation billing flows (HOLD, CAPTURE, REFUND, PENALTY, etc.) with persistent ledgering and idempotent operations.
- Add API endpoints and validation to expose top-up and reservation billing operations for other services.

### Description
- Added project dependencies for JPA, validation, web, Flyway, H2 and test support and enabled Flyway locations in `application.properties`.
- Introduced persistent domain model including `Account`, `AccountOperation`, `ReservationLedger` and enums `AccountStatus`, `OperationType`, `ReservationStatus` plus Flyway migration `V1__account_billing_init.sql` to create tables and indexes.
- Implemented `AccountService` with transactional business logic for `topUp` and `applyReservationBilling` implementing hold, capture, cancel-with-refund-policy, expire (full refund) and no-show penalty semantics and idempotency via `operationId` checks.
- Added `AccountController` REST endpoints and DTOs `TopUpRequest` and `ReservationBillingRequest`, repositories for account/operations/ledger, a `BadRequestException` and `RestExceptionHandler` for consistent error responses.

### Testing
- Added `AccountServiceTest` as a Spring Boot integration test that uses an in-memory H2 database with PostgreSQL compatibility and creates a `users` table for lookups.
- Ran tests with `./gradlew test` and the new `AccountServiceTest` passed (integration test executed against H2 with Flyway disabled in test profile).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aeb88ffa948326b4a2578db7b00811)